### PR TITLE
update web sdk to v0.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@types/react-redux": "^7.1.16",
     "@unumid/demo-types": "git+ssh://git@github.com/UnumID/demo-types.git#v0.1.0",
     "@unumid/types": "git+ssh://git@github.com/UnumID/types.git#v0.0.3",
-    "@unumid/web-sdk": "git+ssh://git@github.com/UnumID/Verifier-Client-SDK.git#v0.2.1",
+    "@unumid/web-sdk": "git+ssh://git@github.com/UnumID/Verifier-Client-SDK.git#v0.2.2",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "react-redux": "^7.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2245,9 +2245,9 @@
   version "0.0.1"
   resolved "git+ssh://git@github.com/UnumID/types.git#c11cdc69f2657d131bae551a80ff36d1b1134e51"
 
-"@unumid/web-sdk@git+ssh://git@github.com/UnumID/Verifier-Client-SDK.git#v0.2.1":
+"@unumid/web-sdk@git+ssh://git@github.com/UnumID/Verifier-Client-SDK.git#v0.2.2":
   version "1.0.0"
-  resolved "git+ssh://git@github.com/UnumID/Verifier-Client-SDK.git#4e68a6161a1125f56c52c4b08e90d08916590f51"
+  resolved "git+ssh://git@github.com/UnumID/Verifier-Client-SDK.git#94efc50416285568a727be448bb6ee18af3154c9"
 
 "@webassemblyjs/ast@1.9.0":
   version "1.9.0"


### PR DESCRIPTION
[ticket](https://trello.com/c/HA8LAw0E/1269-too-little-spacing-below-scanning-instructions)
